### PR TITLE
Dont modify uniform vec4 options

### DIFF
--- a/deffx/materials/rendertarget/scanlines.fp
+++ b/deffx/materials/rendertarget/scanlines.fp
@@ -13,19 +13,20 @@ void main()
 	vec2 pSize = (options.w * sin(var_texcoord0.y * options.y + time.x * options.x)) / vec2(resolution.x, resolution.y);
 	float offsetX = sin(var_texcoord0.y * options.y + time.x * options.x) * pSize.x + cos(var_texcoord0.y * options.y + time.x * options.x * 1.3) * pSize.x;
 	float corner = 500.0;
+	float brightness = options.z;
 
 
 	if(var_texcoord0.x < 0.5) {
 		if(var_texcoord0.y < 0.5) {
-			options.z = min(var_texcoord0.x * var_texcoord0.y * corner, 1.0);
+			brightness = min(var_texcoord0.x * var_texcoord0.y * corner, 1.0);
 		} else {
-			options.z = min(var_texcoord0.x * (1.0 - var_texcoord0.y) * corner, 1.0);
+			brightness = min(var_texcoord0.x * (1.0 - var_texcoord0.y) * corner, 1.0);
 		}
 	} else {
 		if(var_texcoord0.y < 0.5) {
-			options.z = min((1.0 - var_texcoord0.x) * var_texcoord0.y * corner, 1.0);
+			brightness = min((1.0 - var_texcoord0.x) * var_texcoord0.y * corner, 1.0);
 		} else {
-			options.z = min((1.0 - var_texcoord0.x) * (1.0 - var_texcoord0.y) * corner, 1.0);
+			brightness = min((1.0 - var_texcoord0.x) * (1.0 - var_texcoord0.y) * corner, 1.0);
 		}
 	}
 
@@ -34,9 +35,9 @@ void main()
 	float blue = texture2D(DIFFUSE_TEXTURE, vec2(var_texcoord0.x + offsetX, var_texcoord0.y)).b;
 
 	if(mod(var_texcoord0.y * resolution.y, 2.0) > 0.5) {
-		gl_FragColor = vec4(vec3(red, green, blue) * options.z, 1.0);
+		gl_FragColor = vec4(vec3(red, green, blue) * brightness, 1.0);
 	} else {
-		gl_FragColor = vec4(vec3(red * 0.75, green * 0.75, blue * 0.75) * options.z, 1.0);
+		gl_FragColor = vec4(vec3(red * 0.75, green * 0.75, blue * 0.75) * brightness, 1.0);
 	} 
 }
 


### PR DESCRIPTION
With some graphics drivers, changing a uniform value will result in an error compiling the shader

```
 'assign' : l-value required "options" (cannot modify a uniform)
```

This is a fix for this issue